### PR TITLE
Update captcha data to use URL as key

### DIFF
--- a/background.js
+++ b/background.js
@@ -126,21 +126,20 @@ async function updateApiKeys(geminiApiKey, cloudVisionApiKey, sendResponse) {
 
 async function deleteRecord(tab, sendResponse) {
     try {
-        const url = new URL(tab.url);
-        const hostname = url.hostname;
+        const key = tab.url;
 
-        const result = await chrome.storage.local.get(hostname);
-        const data = result[hostname];
+        const result = await chrome.storage.local.get(key);
+        const data = result[key];
 
         if (!data) {
-            sendResponse({ isSuccess: false, error: `No record found for ${hostname}` });
+            sendResponse({ isSuccess: false, error: `No record found for ${key}` });
         } else {
             chrome.tabs.sendMessage(tab.id, {
                 action: "deleteRecord"
             });
 
-            await chrome.storage.local.remove(hostname);
-            sendResponse({ isSuccess: true, message: `Successfully deleted record for ${hostname}` });
+            await chrome.storage.local.remove(key);
+            sendResponse({ isSuccess: true, message: `Successfully deleted record for ${key}` });
         }
     } catch (error) {
         sendResponse({ isSuccess: false, error: error.toString() });

--- a/content.js
+++ b/content.js
@@ -6,7 +6,7 @@ function updateAutoCaptchaData(selectedCaptcha, selectedInput) {
     input_selector = getElementSelector(selectedInput);
 
     chrome.storage.local.set({
-        [window.location.hostname]: {
+        [window.location.href]: {
             captchaSelector: captcha_selector,
             inputSelector: input_selector
         }
@@ -160,8 +160,8 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
     }
 });
 
-chrome.storage.local.get(window.location.hostname, (result) => {
-    let autoCaptchaData = result[window.location.hostname];
+chrome.storage.local.get(window.location.href, (result) => {
+    let autoCaptchaData = result[window.location.href];
     if (!autoCaptchaData)  return;
     
     captcha_selector = autoCaptchaData.captchaSelector;


### PR DESCRIPTION
Instead of using the hostname, this change updates the code to use the full URL as the key for storing and retrieving captcha data. This ensures that captcha data is saved and retrieved correctly for different pages within the same domain.